### PR TITLE
Fixing login attempt with unknown username for #2

### DIFF
--- a/src/Auth/ParseUserProvider.php
+++ b/src/Auth/ParseUserProvider.php
@@ -68,7 +68,13 @@ class ParseUserProvider implements UserProvider
         $query = new ParseQuery('_User');
         $query->equalTo('username', $username);
 
-        return $query->first(true);
+        $user =$query->first(true);
+        
+        if (!empty($user)){
+            return $user;
+        }
+    
+        return  null;
     }
 
     /**

--- a/src/Auth/ParseUserProvider.php
+++ b/src/Auth/ParseUserProvider.php
@@ -68,7 +68,7 @@ class ParseUserProvider implements UserProvider
         $query = new ParseQuery('_User');
         $query->equalTo('username', $username);
 
-        $user =$query->first(true);
+        $user = $query->first(true);
         
         if (!empty($user)){
             return $user;


### PR DESCRIPTION
Ensuring retrieveByCredentials() returns null if no user is found in Parse
