### PR TITLE
Return ParseObject from repository create and update methods

### DIFF
--- a/src/Repositories/AbstractParseRepository.php
+++ b/src/Repositories/AbstractParseRepository.php
@@ -75,7 +75,9 @@ abstract class AbstractParseRepository implements ParseRepository
     {
         $parseClass = new ParseObject($this->getParseClass());
 
-        return $this->setValues($data, $parseClass);
+        $this->setValues($data, $parseClass);
+        
+        return $parseClass;
     }
 
     /**
@@ -88,7 +90,9 @@ abstract class AbstractParseRepository implements ParseRepository
     {
         $parseClass = $this->find($id);
 
-        return $this->setValues($data, $parseClass);
+        $this->setValues($data, $parseClass);
+        
+        return $parseClass;
     }
 
     /**


### PR DESCRIPTION
The function setValues calls deepSave which returns nothing. This way we can use the returned object when creating relations etc.
