### PR TITLE
The app will crash due to an uncaught exception in `ParseUserProvider->retrieveById()`

### DIFF
--- a/src/Auth/ParseUserProvider.php
+++ b/src/Auth/ParseUserProvider.php
@@ -23,7 +23,11 @@ class ParseUserProvider implements UserProvider
     {
         $query = new ParseQuery('_User');
 
-        return $query->get($identifier, true);
+        try {
+            return $query->get($identifier, true);
+        } catch( ParseException $pex) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Add null return value for when the Parse user has been deleted and the session has not been closed.

Although that scenario won't happen frequently on production, during development and testing of registration of user accounts it happens a lot.

Basically, the parse query will throw an exception if the ParseObject with the given id does not exist, if that happens we return null.
