### PR TITLE
The app will crash due to an uncaught ObjectNotFound exception in `ParseUserProvider->retrieveById()`

### DIFF
--- a/src/Auth/ParseUserProvider.php
+++ b/src/Auth/ParseUserProvider.php
@@ -23,7 +23,11 @@ class ParseUserProvider implements UserProvider
     {
         $query = new ParseQuery('_User');
 
-        return $query->get($identifier, true);
+        try {
+            return $query->get($identifier, true);
+        } catch( ParseException $pex) {
+            return null;
+        }
     }
 
     /**

--- a/src/Auth/ParseUserProvider.php
+++ b/src/Auth/ParseUserProvider.php
@@ -12,6 +12,8 @@ use Parse\ParseUser;
 class ParseUserProvider implements UserProvider
 {
 
+    const PEX_OBJECT_NOT_FOUND = 101;
+
     /**
      * Retrieve a user by their unique identifier.
      *
@@ -26,7 +28,12 @@ class ParseUserProvider implements UserProvider
         try {
             return $query->get($identifier, true);
         } catch( ParseException $pex) {
-            return null;
+            // Only return null if it's the object not found exception
+            if ( $pex->getCode() == self::PEX_OBJECT_NOT_FOUND ) {
+                return null;
+            } else {
+                throw $pex;
+            }
         }
     }
 


### PR DESCRIPTION
Returns null when the `retrieveById()` function searches for an user that does not exist and the session has not been closed. It only handles the `Object not found` exception.

Refer to this code segment on the parse sdk to see where the exception is thrown:
- https://github.com/ParsePlatform/parse-php-sdk/blob/master/src/Parse/ParseQuery.php#L79,L97
