### PR TITLE
properly subclass objects returned by repositories

### DIFF
--- a/src/Repositories/AbstractParseRepository.php
+++ b/src/Repositories/AbstractParseRepository.php
@@ -82,8 +82,8 @@ abstract class AbstractParseRepository implements ParseRepository
      */
     public function create(array $data)
     {
-        $parseClass = new ParseObject($this->getParseClass());
-
+        $subClass =  ParseObject::getRegisteredSubclass($this->getParseClass());
+        $parseClass = new $subClass();
         $this->setValues($data, $parseClass);
 
         return $parseClass;


### PR DESCRIPTION
I was having difficulty with `AbstractParseRepository::create` returning generic `ParseObject`s. This PR should fix that. Should close #20 
