### PR TITLE
Feature/parse sdk 1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "laravel/framework": "5.0.*|5.1.*|5.2.*",
-    "parse/php-sdk": "~1.1.2",
+    "parse/php-sdk": "~1.2.0",
     "nesbot/carbon": "~1.16"
   },
   "autoload": {

--- a/config/parse.php
+++ b/config/parse.php
@@ -14,6 +14,7 @@ return [
     |
     */
 
+    'server_url' => env('PARSE_SERVER_URL', ''),
     'app_id'     => env('PARSE_APP_ID', ''),
     'rest_key'   => env('PARSE_REST_KEY', ''),
     'master_key' => env('PARSE_MASTER_KEY', ''),

--- a/src/ParseServiceProvider.php
+++ b/src/ParseServiceProvider.php
@@ -103,6 +103,11 @@ class ParseServiceProvider extends ServiceProvider
 
         // Init the parse client
         ParseClient::initialize($config['app_id'], $config['rest_key'], $config['master_key']);
+        
+        if (empty($config['server_url']) != true) {
+            ParseClient::setServerURL($config['server_url']);
+        }
+        
         ParseClient::setStorage(new ParseSessionStorage($this->app['session']));
     }
 }


### PR DESCRIPTION
Bumped Parse SDK version to use 1.2.0 
Now this is possible to set ParseServer Url, so this is possible to use OpenSource ParseServer instance
